### PR TITLE
fix yeoman-generator to 0.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-aaal",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "An crud interface generator for loopback and angular.",
   "keywords": [
     "yeoman-generator",
@@ -21,7 +21,7 @@
     "lodash": "^3.6.0",
     "underscore.string": "^3.0.3",
     "wiredep": "^2.2.2",
-    "yeoman-generator": "latest",
+    "yeoman-generator": "0.24.1",
     "yosay": "^1.0.3"
   },
   "engines": {


### PR DESCRIPTION
Prevent this error from happening
module.exports = yeoman.Base.extend({
                            ^

TypeError: Cannot read property 'extend' of undefined
    at Object.<anonymous> (/usr/local/lib/node_modules/generator-aaal/app/index.js:13:29)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.defineProperty.get [as aaal:app] (/usr/local/lib/node_modules/yo/node_modules/yeoman-environment/lib/store.js:40:23)
    at Store.get (/usr/local/lib/node_modules/yo/node_modules/yeoman-environment/lib/store.js:64:35)
    at Environment.get (/usr/local/lib/node_modules/yo/node_modules/yeoman-environment/lib/environment.js:262:16)